### PR TITLE
Correct SQL error on upgrade into 0.90

### DIFF
--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -59,10 +59,10 @@ class PluginMreportingNotification extends CommonDBTM {
             'event'                    => 'sendReporting',
             'mode'                     => 'mail',
          ));
-      }
-
-      $DB->query('INSERT INTO glpi_notificationtargets (items_id, type, notifications_id)
+         
+         $DB->query('INSERT INTO glpi_notificationtargets (items_id, type, notifications_id)
                VALUES (1, 1, ' . $notification_id . ');');
+      }
 
        return array('success' => true);
    }


### PR DESCRIPTION
2015-10-07 15:02:40 [6@VS-GLPI01]
  *** MySQL query error:
  SQL: INSERT INTO glpi_notificationtargets (items_id, type, notifications_id)
               VALUES (1, 1, );
  Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 2
  Backtrace :
  plugins/mreporting/inc/notification.class.php:65   
  plugins/mreporting/hook.php:177                    PluginMreportingNotification::install()
  inc/plugin.class.php:643                           plugin_mreporting_install()
  front/plugin.form.php:49                           Plugin->install()