### PR TITLE
Fix PHP fatal error and can't display any graphs

### DIFF
--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -1155,7 +1155,7 @@ class PluginMreportingCommon extends CommonDBTM {
          $obj = new $classname($config);
 
          //dynamic call of method passed by 'f_name' GET parameter with previously instancied class
-         $datas = $obj->$opt['f_name']($config);
+         $datas = $obj->{$opt['f_name']}($config);
 
          //show graph (pgrah type determined by first entry of explode of camelcase of function name
          $title_func = $LANG['plugin_mreporting'][$opt['short_classname']][$opt['f_name']]['title'];

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -609,7 +609,7 @@ class PluginMreportingCommon extends CommonDBTM {
 
       //dynamic call of method passed by 'f_name' GET parameter with previously instancied class
       $obj = new $classname($config);
-      $datas = $obj->$opt['f_name']($config);
+      $datas = $obj->{$opt['f_name']}($config);
 
       //show graph (pgrah type determined by first entry of explode of camelcase of function name
       $title_func = $LANG['plugin_mreporting'][$opt['short_classname']][$opt['f_name']]['title'];


### PR DESCRIPTION
The error in PHP 7 :
```
[18-Feb-2016 10:14:37 UTC] PHP Fatal error:  Uncaught Error: Function name must be a string in /data/glpi/glpi/plugins/mreporting/inc/common.class.php:612
Stack trace:
#0 /data/glpi/glpi/plugins/mreporting/front/graph.php(38): PluginMreportingCommon->showGraph(Array)
#1 {main}
  thrown in /data/glpi/glpi/plugins/mreporting/inc/common.class.php on line 612
```