### PR TITLE
Fixing inc/helpdeskplus.class.php

### DIFF
--- a/inc/helpdeskplus.class.php
+++ b/inc/helpdeskplus.class.php
@@ -9,7 +9,7 @@ class PluginMreportingHelpdeskplus Extends PluginMreportingBaseclass {
    protected $sql_group_assign  = "1=1",
              $sql_group_request = "1=1",
              $sql_user_assign   = "1=1",
-             $sql_type          = "glpi_tickets.type = ".Ticket::INCIDENT_TYPE,
+             $sql_type          = "glpi_tickets.type IN (".Ticket::INCIDENT_TYPE.", ".Ticket::DEMAND_TYPE.")",
              $sql_itilcat       = "1=1",
 
              $sql_join_cat      = "LEFT JOIN glpi_itilcategories cat


### PR DESCRIPTION
Fixing helpdeskplus : ticket type "all" wasn't checked (never), so reports always return incident tickets when "all" was selected. Now reports return all kind of tickets when selecting all