### PR TITLE
getLoginUserId sometime return true for an incomplete session in case of cron

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -77,7 +77,7 @@ function plugin_init_mreporting() {
       //Load additionnal language files in needed
       includeAdditionalLanguageFiles();
 
-      if (Session::getLoginUserID()) {
+      if (Session::getCurrentInterface()) {
          /* Profile */
          $PLUGIN_HOOKS['change_profile']['mreporting'] = ['PluginMreportingProfile',
                                                           'changeProfile'];


### PR DESCRIPTION
i don't have anymore the backtrace but here https://github.com/pluginsGLPI/mreporting/blob/1.5.2/setup.php#L99
we parse GLPI session, with cron execution, getLoginUserId can return true if param force_human is set to true when fusion import triggers (by cli)