### PR TITLE
ALTER IGNORE cause an error

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -157,7 +157,7 @@ function plugin_mreporting_install() {
    $query = "UPDATE `glpi_plugin_mreporting_profiles` pr SET pr.right = ".READ." WHERE pr.right = 'r'";
    $DB->query($query);
    if (!isIndex('glpi_plugin_mreporting_profiles', 'profiles_id_reports')) {
-      $query = "ALTER IGNORE TABLE glpi_plugin_mreporting_profiles
+      $query = "ALTER TABLE glpi_plugin_mreporting_profiles
                 ADD UNIQUE INDEX `profiles_id_reports` (`profiles_id`, `reports`)";
       $DB->query($query);
    }


### PR DESCRIPTION
Hello,

In migration code of this plugin there is a SQL query with "ALTER IGNORE" inside, but since 5.7.4 the "IGNORE" keyword has been removed from ALTER command and generate an error.

Simply removed the IGNORE keyword in this commit, no longer needed in lastest version.