### PR TITLE
Fix missing javascript loading

### DIFF
--- a/ajax/dashboard.php
+++ b/ajax/dashboard.php
@@ -29,8 +29,7 @@ if (isset($_REQUEST['action'])) {
          echo Html::script("/plugins/mreporting/lib/protovis/protovis.min.js", ['version' => $version]);
          echo Html::script("/plugins/mreporting/lib/protovis-msie/protovis-msie.min.js", ['version' => $version]);
 
-         echo "</body>";
-         echo "</html>";
+         Html::popFooter();
          break;
 
       default:


### PR DESCRIPTION
Dashboard iframe can use some GLPI JS functions, so they have to be loaded (JS is loaded in footer).

Example (on current state of 9.3/bugfixes branch of GLPI)
 - add "Computer by manufacturer" report to the dashboard,
 - try to configure it.
-> A JS error appears, as the form will contain the states dropdown, using `templateResult` JS function.