### PR TITLE
Added a isset() to prevent php error log file to be flooded with "undefined index: f_name" messages

### DIFF
--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -1682,8 +1682,9 @@ class PluginMreportingCommon extends CommonDBTM {
    static function getReportSelectors($export = false) {
       ob_start();
       self::addToSelector();
-      $graphname = $_REQUEST['f_name'];
-      if (!isset($_SESSION['mreporting_selector'][$graphname])
+      $graphname = isset($_REQUEST['f_name']) ? $_REQUEST['f_name'] : false;
+      if (!$graphname
+         || !isset($_SESSION['mreporting_selector'][$graphname])
          || empty($_SESSION['mreporting_selector'][$graphname])) {
          return;
       }

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -1779,7 +1779,7 @@ class PluginMreportingCommon extends CommonDBTM {
       $selectors = PluginMreportingPreference::checkPreferenceValue('selectors', Session::getLoginUserID());
       if ($selectors) {
          $values = json_decode(stripslashes($selectors), true);
-         if (isset($values[$_REQUEST['f_name']])) {
+         if (isset($_REQUEST['f_name']) && isset($values[$_REQUEST['f_name']])) {
             foreach ($values[$_REQUEST['f_name']] as $key => $value) {
                $myvalues[$key] = $value;
             }


### PR DESCRIPTION
In some cases, the f_name index is not defined, and then php error log is flooded with messages like:
2019-10-30 04:29:27 [15941@XXXXXXX]
  *** PHP Notice(8): Undefined index: f_name
  Backtrace :
  plugins\mreporting\inc\common.class.php:1676       
  plugins\mreporting\inc\dashboard.class.php:328     PluginMreportingCommon::getReportSelectors()
  plugins\mreporting\ajax\dashboard.php:18           PluginMreportingDashboard::getConfig()

So I added a isset() to prevent these messages