### PR TITLE
Fix deprecated usage of $order param in getAllDataFromTable

### DIFF
--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -1298,7 +1298,8 @@ class PluginMreportingCommon extends CommonDBTM {
       }
 
       $datas = [];
-      foreach (getAllDataFromTable('glpi_groups', $condition, false, 'name') as $data) {
+      $condition['ORDER'] = 'name';
+      foreach (getAllDataFromTable('glpi_groups', $condition, false) as $data) {
          $datas[$data['id']] = $data['completename'];
       }
 


### PR DESCRIPTION
hello,
I set the key of the array $condition['ORDER'] with 'name' in order to respect the new syntax of GLPI plugin

regards