### PR TITLE
fix(menu): missing title

### DIFF
--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -73,6 +73,7 @@ class PluginMreportingCommon extends CommonDBTM {
 
       $menu['page'] = PluginMreportingDashboard::CurrentUserHaveDashboard() ? $url_dashboard : $url_central;
       $menu['icon'] = self::getIcon();
+      $menu['title'] = self::getTypeName(Session::getPluralNumber());
 
       $menu['options']['dashboard']['page']            = $url_dashboard;
       $menu['options']['dashboard']['title']           = __("Dashboard", 'mreporting');


### PR DESCRIPTION
The title was missing, which in some cases generated an error in the menu:

```
Uncaught Exception TypeError: Argument 1 passed to Glpi\Application\View\Extension\DataHelpersExtension::underlineShortcutLetter() must be of the type string, null given, called in ***/glpi_files/_cache/templates/d0/d0ad71d338d8ea48a4f6c98dc918646397d42422e1afcf876b5a913091873224.php on line 202 in ***/htdocs/src/Application/View/Extension/DataHelpersExtension.php at line 148
```

_Internal reference: !24661_