### PR TITLE
fix: no data when period = week

### DIFF
--- a/inc/baseclass.class.php
+++ b/inc/baseclass.class.php
@@ -116,7 +116,7 @@ class PluginMreportingBaseclass {
                break;
             case 'week':
                $this->period_sort = '%x%v';
-               $this->period_sort_php = 'YV';
+               $this->period_sort_php = 'oW';
                $this->period_datetime = "%Y-%m-%d 23:59:59";
                $this->period_label = 'S%v %x';
                $this->period_interval = 'WEEK';


### PR DESCRIPTION
When "week" is selected for the period and the start and end dates are in the same year, no data was displayed.

Example: January 1, 2023:
![image](https://github.com/pluginsGLPI/mreporting/assets/8530352/0cc690a2-7f9b-427b-88fa-66b8734fbb42)

But if you add the previous day in 2022, the data is displayed:
![image](https://github.com/pluginsGLPI/mreporting/assets/8530352/54bf1c82-9ba7-4158-acf1-ddd64b685635)

https://www.php.net/manual/en/datetime.format.php

internal ref: !30037
