### PR TITLE
Fix labels for select dropdowns

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -694,7 +694,7 @@ class PluginMreportingConfig extends CommonDBTM
         Dropdown::showYesNo("show_graph", $this->fields["show_graph"]);
         echo "</td>";
 
-        echo "<td>" . __("Default chart format") . "</td>";
+        echo "<td>" . __("Default chart format", 'mreporting') . "</td>";
         echo "<td>";
         Dropdown::showFromArray(
             "graphtype",
@@ -738,7 +738,7 @@ class PluginMreportingConfig extends CommonDBTM
         echo "</td>";
 
         echo "<td>";
-        echo __("Curve lines (SVG)", 'mreporting');
+        echo __("See values", 'mreporting');
         echo "</td>";
 
         echo "<td>";


### PR DESCRIPTION
Fix non-translated and duplicate label for dropdowns in configuration

* Label "Default chart format" had missing function parameter 'mreporting', so it wasn't translated.
* Same label "Curve lines (SVG)" was wrongly used for another label on select show_label.