### PR TITLE
Issue #253 - Fixes deprecated dynamic property in baseclass.class.php

### DIFF
--- a/inc/baseclass.class.php
+++ b/inc/baseclass.class.php
@@ -38,7 +38,7 @@ class PluginMreportingBaseclass
     protected $where_entities;
     protected $where_entities_array;
     protected $where_entities_level;
-	protected $period_sort;
+    protected $period_sort;
     protected $period_sort_php;
     protected $period_datetime;
     protected $period_label;

--- a/inc/baseclass.class.php
+++ b/inc/baseclass.class.php
@@ -38,6 +38,13 @@ class PluginMreportingBaseclass
     protected $where_entities;
     protected $where_entities_array;
     protected $where_entities_level;
+	protected $period_sort;
+    protected $period_sort_php;
+    protected $period_datetime;
+    protected $period_label;
+    protected $period_interval;
+    protected $sql_list_date;
+    protected $status;
 
     public function __construct($config = [])
     {
@@ -69,7 +76,8 @@ class PluginMreportingBaseclass
                 ],
             ],
         ];
-        $this->status = [CommonITILObject::INCOMING,
+        $this->status = [
+            CommonITILObject::INCOMING,
             CommonITILObject::ASSIGNED,
             CommonITILObject::PLANNED,
             CommonITILObject::WAITING,


### PR DESCRIPTION
## Description

- It fixes #253
- Fixes the issue of deprecated dynamic property creation in the PluginMreportingBaseclass class for PHP 8.2 and newer versions. The following changes were made:
- Defined the properties $period_sort, $period_sort_php, $period_datetime, $period_label, $period_interval, $sql_list_date, and $status within the class to avoid deprecated dynamic property creation warnings.
- Ensured compatibility with PHP 8.2 by preventing the creation of dynamic properties at runtime.
- These changes resolve the warnings and errors related to deprecated dynamic property creation.
