### PR TITLE
Fix dynamic properties and png rendering deprecations

### DIFF
--- a/inc/baseclass.class.php
+++ b/inc/baseclass.class.php
@@ -31,6 +31,7 @@
 class PluginMreportingBaseclass
 {
     protected $sql_date;
+    protected $sql_closedate;
     protected $sql_date_create;
     protected $sql_date_solve;
     protected $sql_date_closed;

--- a/inc/graphpng.class.php
+++ b/inc/graphpng.class.php
@@ -2492,7 +2492,7 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
                             $x2, $height - $x_labels_height,
                             $x1, $height - $x_labels_height,
                         ];
-                        imagefilledpolygon($image, $points, 4, hexdec($alphapalette[$index1]));
+                        imagefilledpolygon($image, $points, hexdec($alphapalette[$index1]));
                     }
 
                     //trace lines between points (if linear)

--- a/inc/graphpng.class.php
+++ b/inc/graphpng.class.php
@@ -67,11 +67,11 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
             $width = $this->width + 100;
 
             if (!isset($_REQUEST['date1' . $randname])) {
-                $_REQUEST['date1' . $randname] = strftime('%Y-%m-%d', time()
+                $_REQUEST['date1' . $randname] = date('Y-m-d', time()
                  - ($options['delay'] * 24 * 60 * 60));
             }
             if (!isset($_REQUEST['date2' . $randname])) {
-                $_REQUEST['date2' . $randname] = strftime('%Y-%m-%d');
+                $_REQUEST['date2' . $randname] = date('Y-m-d');
             }
 
             $backtrace     = debug_backtrace();
@@ -404,31 +404,31 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
                     continue;
                 }
 
-                $trgb = ImageColorAt($image, $x, (int) floor($y));
+                $trgb = ImageColorAt($image, floor($x), floor($y));
                 $tcr  = ($trgb >> 16) & 0xFF;
                 $tcg  = ($trgb >> 8)  & 0xFF;
                 $tcb  = $trgb         & 0xFF;
                 imagesetpixel(
                     $image,
-                    $x,
-                    (int) floor($y),
+                    floor($x),
+                    floor($y),
                     imagecolorallocatealpha(
                         $image,
-                        (int) round($tcr * $ya + $icr * $yb),
-                        (int) ($tcg * $ya + $icg * $yb),
-                        (int) ($tcb * $ya + $icb * $yb),
+                        round($tcr * $ya + $icr * $yb),
+                        round($tcg * $ya + $icg * $yb),
+                        round($tcb * $ya + $icb * $yb),
                         hexdec($alpha),
                     ),
                 );
 
-                $trgb = ImageColorAt($image, $x, (int) ceil($y));
+                $trgb = ImageColorAt($image, ceil($x), ceil($y));
                 $tcr  = ($trgb >> 16) & 0xFF;
                 $tcg  = ($trgb >> 8)  & 0xFF;
                 $tcb  = $trgb         & 0xFF;
                 imagesetpixel(
                     $image,
-                    $x,
-                    (int) ceil($y),
+                    ceil($x),
+                    ceil($y),
                     imagecolorallocatealpha(
                         $image,
                         (int) round($tcr * $yb + $icr * $ya),
@@ -681,9 +681,9 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
             $index = 0;
             foreach ($datas as $label => $data) {
                 $bx1 = 250;
-                $by1 = ($index + 1) * 1.25 * $height_bar + .05 * $height + 2;
+                $by1 = round(($index + 1) * 1.25 * $height_bar + .05 * $height + 2);
                 $bx2 = $bx1                              + round(($data * ($width - 300)) / $max);
-                $by2 = $by1                              + $height_bar;
+                $by2 = round($by1                              + $height_bar);
 
                 //createbar
                 ImageFilledRectangle($image, $bx1, (int) $by1, (int) $bx2, (int) $by2, hexdec($palette[$index]));
@@ -922,8 +922,8 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
 
                     //text associated with pie arc (only for angle > 2°)
                     if ($angle > 2 && ($show_label == 'always' || $show_label == 'hover')) {
-                        $xtext = $x                 - 1 + cos(deg2rad(($start_angle + $angle) / 2)) * ($radius / 1.7);
-                        $ytext = $y             + 5 - sin(deg2rad(($start_angle + $angle) / 2))     * ($radius / 1.7);
+                        $xtext = round($x                 - 1 + cos(deg2rad(($start_angle + $angle) / 2)) * ($radius / 1.7));
+                        $ytext = round($y             + 5 - sin(deg2rad(($start_angle + $angle) / 2))     * ($radius / 1.7));
                         imagettftext(
                             $image,
                             $this->fontsize,
@@ -1274,12 +1274,12 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
             //define label position
             if (is_array($data)) {
                 //show label inside its arc
-                $xtext = $x                                                             - $dx * $tw + cos($amr) * (0.5 * $radius - $step / 3);
-                $ytext = $y                                     + $dy                         * $th - sin($amr) * (0.5 * $radius - $step / 4);
+                $xtext = round($x - $dx * $tw + cos($amr) * (0.5 * $radius - $step / 3));
+                $ytext = round($y + $dy * $th - sin($amr) * (0.5 * $radius - $step / 4));
             } else {
                 //show label outside of its arc
-                $xtext = $x + 3                     - $dx * $tw + cos($amr) * (0.5 * $radius + $step / 16);
-                $ytext = $y + $dy                         * $th - sin($amr) * (0.5 * $radius + $step / 8);
+                $xtext = round($x + 3 - $dx * $tw + cos($amr) * (0.5 * $radius + $step / 16));
+                $ytext = round($y + $dy * $th - sin($amr) * (0.5 * $radius + $step / 8));
             }
 
             //draw label
@@ -1310,8 +1310,8 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
                 $th = abs($box[5] - $box[1]);
 
                 //define label position
-                $xtext = $x                                                             - $dx * $tw + cos($samr) * (0.5 * $radius - $step / 8);
-                $ytext = $y                                     + $dy                         * $th - sin($samr) * (0.5 * $radius - $step / 16);
+                $xtext = round($x - $dx * $tw + cos($samr) * (0.5 * $radius - $step / 8));
+                $ytext = round($y + $dy * $th - sin($samr) * (0.5 * $radius - $step / 16));
 
                 //draw label
                 imagettftext(
@@ -1715,10 +1715,10 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
         if ($dashboard) {
             $height = 350;
         }
-        $x_bar           = (0.85 * $this->width / $nb_bar);
-        $width_bar       = $x_bar         * .85;
-        $y_labels_width  = .1             * $this->width;
-        $x_labels_height = $height - 0.95 * $height;
+        $x_bar           = round(0.85 * $this->width / $nb_bar);
+        $width_bar       = round($x_bar         * .85);
+        $y_labels_width  = round(.1             * $this->width);
+        $x_labels_height = round($height - 0.95 * $height);
         $legend_height   = $nb_labels2    * 15 + 10;
 
         //longueur du texte en dessous des barres
@@ -1753,8 +1753,8 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
             //draw x-axis grey step line and values ticks
             $xstep = round(($height - $legend_height - $x_labels_height) / 12);
             for ($i = 0; $i <= 12; $i++) {
-                $yaxis = $height - $x_labels_height - $xstep * $i;
-                imageLine($image, (int) (.9 * $y_labels_width), (int) $yaxis, (int) (0.95 * $this->width), (int) $yaxis, hexdec($this->grey));
+                $yaxis = round($height - $x_labels_height - $xstep * $i);
+                imageLine($image, round(.9 * $y_labels_width), $yaxis, round(0.95 * $this->width), $yaxis, hexdec($this->grey));
 
                 //value label
                 $val       = round($i * $cum / 12, 1);
@@ -1822,7 +1822,7 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
                 foreach ($data as $subdata) {
                     $by1 = $by2;
                     $bx1 = $y_labels_width + $index1 * $x_bar;
-                    $by2 = $by1 - $subdata           * ($height - $legend_height - $x_labels_height) / $cum;
+                    $by2 = round($by1 - $subdata           * ($height - $legend_height - $x_labels_height) / $cum);
                     $bx2 = $bx1 + $width_bar;
 
                     if ($by1 != $by2) { // no draw for empty datas
@@ -1855,7 +1855,7 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
                 $textwidth = abs($box[4] - $box[6]);
                 $textwidth = abs(sqrt((pow($textwidth, 2) / 2)));
 
-                $lx = $y_labels_width + $index1 * $x_bar + ($width_bar / 2.5);
+                $lx = round($y_labels_width + $index1 * $x_bar + ($width_bar / 2.5));
                 imagettftext(
                     $image,
                     $this->fontsize - 1,
@@ -2030,7 +2030,7 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
         $nb         = count($datas);
         $width      = $this->width;
         $height     = 350;
-        $width_line = ($width - 45) / $nb;
+        $width_line = round(($width - 45) / $nb);
         $step       = ceil($nb / 20);
 
         //create image
@@ -2125,9 +2125,9 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
 
                 // determine coords
                 $x1           = $index                                                               * $width_line - $width_line + 30;
-                $y1           = $height                                             - 30 - $old_data * ($height - 85) / $max;
+                $y1           = floor($height                                             - 30 - $old_data * ($height - 85) / $max);
                 $x2           = $x1 + $width_line;
-                $y2           = $height - 30 - $data * ($height - 85) / $max;
+                $y2           = floor($height - 30 - $data * ($height - 85) / $max);
                 $aCoords[$x1] = $y1;
 
                 //in case of area chart fill under point space
@@ -2138,7 +2138,7 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
                         $x2, $height - 30,
                         $x1, $height - 30,
                     ];
-                    imagefilledpolygon($image, $points, 4, hexdec($alphapalette[0]));
+                    imagefilledpolygon($image, $points, hexdec($alphapalette[0]));
                 }
 
                 //trace lines between points (if linear)
@@ -2170,9 +2170,9 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
 
                 // determine coords
                 $x1 = $index                                                               * $width_line - $width_line + 30;
-                $y1 = $height                                             - 30 - $old_data * ($height - 85) / $max;
+                $y1 = floor($height                                             - 30 - $old_data * ($height - 85) / $max);
                 $x2 = $x1 + $width_line;
-                $y2 = $height - 30 - $data * ($height - 85) / $max;
+                $y2 = floor($height - 30 - $data * ($height - 85) / $max);
 
                 //trace dots
                 $color_rbg = self::colorHexToRGB($darkerpalette[0]);

--- a/inc/graphpng.class.php
+++ b/inc/graphpng.class.php
@@ -2372,7 +2372,7 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
         $nb_bar     = count($labels2);
         $nb_labels2 = count($datas);
 
-        $width_line = ($this->width - 45) / $nb;
+        $width_line = floor(($this->width - 45) / $nb);
         $index1     = 0;
         $index3     = 1;
         $step       = ceil($nb / 21);
@@ -2479,10 +2479,10 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
                     }
 
                     // determine coords
-                    $x1 = $index2                                                                                           * $width_line - $width_line + $x_bar;
-                    $y1 = $height                                                            - $x_labels_height - $old_data * ($height - $legend_height - $x_labels_height) / $max;
+                    $x1 = $index2 * $width_line - $width_line + $x_bar;
+                    $y1 = round($height - $x_labels_height - $old_data * ($height - $legend_height - $x_labels_height) / $max);
                     $x2 = $x1 + $width_line;
-                    $y2 = $height - $x_labels_height - $subdata * ($height - $legend_height - $x_labels_height) / $max;
+                    $y2 = round($height - $x_labels_height - $subdata * ($height - $legend_height - $x_labels_height) / $max);
 
                     //in case of area chart fill under point space
                     if ($area > 0) {

--- a/inc/graphpng.class.php
+++ b/inc/graphpng.class.php
@@ -404,31 +404,31 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
                     continue;
                 }
 
-                $trgb = ImageColorAt($image, floor($x), floor($y));
+                $trgb = ImageColorAt($image, (int) floor($x), (int) floor($y));
                 $tcr  = ($trgb >> 16) & 0xFF;
                 $tcg  = ($trgb >> 8)  & 0xFF;
                 $tcb  = $trgb         & 0xFF;
                 imagesetpixel(
                     $image,
-                    floor($x),
-                    floor($y),
+                    (int) floor($x),
+                    (int) floor($y),
                     imagecolorallocatealpha(
                         $image,
-                        round($tcr * $ya + $icr * $yb),
-                        round($tcg * $ya + $icg * $yb),
-                        round($tcb * $ya + $icb * $yb),
+                        (int) round($tcr * $ya + $icr * $yb),
+                        (int) ($tcg * $ya + $icg * $yb),
+                        (int) ($tcb * $ya + $icb * $yb),
                         hexdec($alpha),
                     ),
                 );
 
-                $trgb = ImageColorAt($image, ceil($x), ceil($y));
+                $trgb = ImageColorAt($image, (int) ceil($x), (int) ceil($y));
                 $tcr  = ($trgb >> 16) & 0xFF;
                 $tcg  = ($trgb >> 8)  & 0xFF;
                 $tcb  = $trgb         & 0xFF;
                 imagesetpixel(
                     $image,
-                    ceil($x),
-                    ceil($y),
+                    (int) ceil($x),
+                    (int) ceil($y),
                     imagecolorallocatealpha(
                         $image,
                         (int) round($tcr * $yb + $icr * $ya),
@@ -1754,7 +1754,7 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
             $xstep = round(($height - $legend_height - $x_labels_height) / 12);
             for ($i = 0; $i <= 12; $i++) {
                 $yaxis = round($height - $x_labels_height - $xstep * $i);
-                imageLine($image, round(.9 * $y_labels_width), $yaxis, round(0.95 * $this->width), $yaxis, hexdec($this->grey));
+                imageLine($image, (int) round(.9 * $y_labels_width), (int) $yaxis, (int) round(0.95 * $this->width), (int) $yaxis, hexdec($this->grey));
 
                 //value label
                 $val       = round($i * $cum / 12, 1);
@@ -2030,7 +2030,7 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
         $nb         = count($datas);
         $width      = $this->width;
         $height     = 350;
-        $width_line = round(($width - 45) / $nb);
+        $width_line = (int) round(($width - 45) / $nb);
         $step       = ceil($nb / 20);
 
         //create image
@@ -2138,7 +2138,7 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
                         $x2, $height - 30,
                         $x1, $height - 30,
                     ];
-                    imagefilledpolygon($image, $points, hexdec($alphapalette[0]));
+                    imagefilledpolygon($image, $points, 4, hexdec($alphapalette[0]));
                 }
 
                 //trace lines between points (if linear)
@@ -2170,9 +2170,9 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
 
                 // determine coords
                 $x1 = $index                                                               * $width_line - $width_line + 30;
-                $y1 = floor($height                                             - 30 - $old_data * ($height - 85) / $max);
+                $y1 = (int) floor($height                                             - 30 - $old_data * ($height - 85) / $max);
                 $x2 = $x1 + $width_line;
-                $y2 = floor($height - 30 - $data * ($height - 85) / $max);
+                $y2 = (int) floor($height - 30 - $data * ($height - 85) / $max);
 
                 //trace dots
                 $color_rbg = self::colorHexToRGB($darkerpalette[0]);
@@ -2372,7 +2372,7 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
         $nb_bar     = count($labels2);
         $nb_labels2 = count($datas);
 
-        $width_line = floor(($this->width - 45) / $nb);
+        $width_line = (int) floor(($this->width - 45) / $nb);
         $index1     = 0;
         $index3     = 1;
         $step       = ceil($nb / 21);
@@ -2480,9 +2480,9 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
 
                     // determine coords
                     $x1 = $index2 * $width_line - $width_line + $x_bar;
-                    $y1 = round($height - $x_labels_height - $old_data * ($height - $legend_height - $x_labels_height) / $max);
+                    $y1 = (int) round($height - $x_labels_height - $old_data * ($height - $legend_height - $x_labels_height) / $max);
                     $x2 = $x1 + $width_line;
-                    $y2 = round($height - $x_labels_height - $subdata * ($height - $legend_height - $x_labels_height) / $max);
+                    $y2 = (int) round($height - $x_labels_height - $subdata * ($height - $legend_height - $x_labels_height) / $max);
 
                     //in case of area chart fill under point space
                     if ($area > 0) {
@@ -2492,7 +2492,7 @@ class PluginMreportingGraphpng extends PluginMreportingGraph
                             $x2, $height - $x_labels_height,
                             $x1, $height - $x_labels_height,
                         ];
-                        imagefilledpolygon($image, $points, hexdec($alphapalette[$index1]));
+                        imagefilledpolygon($image, $points, 4, hexdec($alphapalette[$index1]));
                     }
 
                     //trace lines between points (if linear)

--- a/inc/helpdesk.class.php
+++ b/inc/helpdesk.class.php
@@ -918,7 +918,7 @@ class PluginMreportingHelpdesk extends PluginMreportingBaseclass
             foreach ($technicians as $technician) {
                 $datas['datas'][$current_status][$technician['username']] = 0;
 
-                $fullname = trim($technician['fullname']);
+                $fullname = trim($technician['fullname'] ?? "");
                 if (!empty($fullname)) {
                     $datas['labels2'][$technician['username']] = $fullname;
                 } else {

--- a/inc/notificationtargetnotification.class.php
+++ b/inc/notificationtargetnotification.class.php
@@ -154,16 +154,19 @@ class PluginMreportingNotificationTargetNotification extends NotificationTarget
             $image_width  = imagesx($image);
             $image_height = imagesy($image);
 
-            $format = '%e';
-            if (strftime('%Y', strtotime($graph['start'])) != strftime('%Y', strtotime($graph['end']))) {
-                $format .= ' %B %Y';
-            } elseif (strftime('%B', strtotime($graph['start'])) != strftime('%B', strtotime($graph['end']))) {
-                $format .= ' %B';
+            $start = new DateTime($graph['start']);
+            $end   = new DateTime($graph['end']);
+
+            $format = 'j';
+            if ($start->format('Y') != $end->format('Y')) {
+                $format .= ' F Y';
+            } elseif ($start->format('F') != $end->format('F')) {
+                $format .= ' F';
             }
 
             $image_title = $LANG['plugin_mreporting'][$graph['class']][$graph['method']]['title'];
-            $image_title .= ' du ' . strftime($format, strtotime($graph['start']));
-            $image_title .= ' au ' . strftime('%e %B %Y', strtotime($graph['end']));
+            $image_title .= ' du ' . $start->format($format);
+            $image_title .= ' au ' . $end->format('j F Y');
 
             array_push($images, ['title' => $image_title,
                 'base64'                 => $image_base64,

--- a/inc/notificationtargetnotification.class.php
+++ b/inc/notificationtargetnotification.class.php
@@ -157,17 +157,21 @@ class PluginMreportingNotificationTargetNotification extends NotificationTarget
             $start = new DateTime($graph['start']);
             $end   = new DateTime($graph['end']);
 
-            $format = 'j';
+            $format = 'd';
             if ($start->format('Y') != $end->format('Y')) {
-                $format .= ' F Y';
+                $format .= ' MMMM y';
             } elseif ($start->format('F') != $end->format('F')) {
-                $format .= ' F';
+                $format .= ' MMMM';
             }
 
+            $language = $_SESSION['glpilanguage'] ?? 'en_GB';
             $image_title = $LANG['plugin_mreporting'][$graph['class']][$graph['method']]['title'];
-            $image_title .= ' du ' . $start->format($format);
-            $image_title .= ' au ' . $end->format('j F Y');
-
+            $image_title .= ' ' . lcfirst(
+                sprintf(__('From %1$s to %2$s'),
+                    IntlDateFormatter::formatObject($start, $format, $language),
+                    IntlDateFormatter::formatObject($end, 'd MMMM Y', $language)
+                )
+            );
             array_push($images, ['title' => $image_title,
                 'base64'                 => $image_base64,
                 'width'                  => $image_width,

--- a/inc/notificationtargetnotification.class.php
+++ b/inc/notificationtargetnotification.class.php
@@ -167,10 +167,11 @@ class PluginMreportingNotificationTargetNotification extends NotificationTarget
             $language = $_SESSION['glpilanguage'] ?? 'en_GB';
             $image_title = $LANG['plugin_mreporting'][$graph['class']][$graph['method']]['title'];
             $image_title .= ' ' . lcfirst(
-                sprintf(__('From %1$s to %2$s'),
+                sprintf(
+                    __('From %1$s to %2$s'),
                     IntlDateFormatter::formatObject($start, $format, $language),
-                    IntlDateFormatter::formatObject($end, 'd MMMM Y', $language)
-                )
+                    IntlDateFormatter::formatObject($end, 'd MMMM Y', $language),
+                ),
             );
             array_push($images, ['title' => $image_title,
                 'base64'                 => $image_base64,

--- a/lib/cubic_splines/classes/CubicSplines.php
+++ b/lib/cubic_splines/classes/CubicSplines.php
@@ -110,7 +110,7 @@ class CubicSplines
                 $i = 0;
                 $j = $n - 1;
                 while ($i + 1 < $j) {
-                    $k = $i + ($j - $i) / 2;
+                    $k = floor($i + ($j - $i) / 2);
                     if ($x <= $this->aSplines[$k]['x']) {
                         $j = $k;
                     } else {

--- a/lib/cubic_splines/classes/Plot.php
+++ b/lib/cubic_splines/classes/Plot.php
@@ -48,7 +48,7 @@ class Plot
         imageline($vImage, $iPosX, $iPosY, $iPosX, 0, $vColor);
         imageline($vImage, $iPosX, $iPosY, $vImageWidth, $iPosY, $vColor);
 
-        imagefilledpolygon($vImage, [$iPosX, 0, $iPosX - 3, 5, $iPosX + 3, 5], 3, $vColor);
-        imagefilledpolygon($vImage, [$vImageWidth, $iPosY, $vImageWidth - 5, $iPosY - 3, $vImageWidth - 5, $iPosY + 3], 3, $vColor);
+        imagefilledpolygon($vImage, [$iPosX, 0, $iPosX - 3, 5, $iPosX + 3, 5], $vColor);
+        imagefilledpolygon($vImage, [$vImageWidth, $iPosY, $vImageWidth - 5, $iPosY - 3, $vImageWidth - 5, $iPosY + 3], $vColor);
     }
 }

--- a/lib/imagesmootharc/imageSmoothArc.php
+++ b/lib/imagesmootharc/imageSmoothArc.php
@@ -118,7 +118,7 @@ function imageSmoothArcDrawSegment(&$img, $cx, $cy, $a, $b, $aaAngleX, $aaAngleY
                     $ya = +1;
                 }
                 if ($stop < ($i + 1) * (M_PI / 2) && $x <= $xStop) {
-                    $diffColor1 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], 127 - (127 - $color[3]) * $error1);
+                    $diffColor1 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], round(127 - (127 - $color[3]) * $error1));
                     $y1         = $_y1;
                     if ($aaStopX) {
                         imageSetPixel($img, $cx + $xp * ($x) + $xa, $cy + $yp * ($y1 + 1) + $ya, $diffColor1);
@@ -127,14 +127,14 @@ function imageSmoothArcDrawSegment(&$img, $cx, $cy, $a, $b, $aaAngleX, $aaAngleY
                     $y         = $b * sqrt(1 - ($x * $x) / ($a * $a));
                     $error     = $y - (int) ($y);
                     $y         = (int) ($y);
-                    $diffColor = imageColorExactAlpha($img, $color[0], $color[1], $color[2], 127 - (127 - $color[3]) * $error);
+                    $diffColor = imageColorExactAlpha($img, $color[0], $color[1], $color[2], round(127 - (127 - $color[3]) * $error));
                     $y1        = $y;
                     if ($x < $aaAngleX) {
                         imageSetPixel($img, $cx + $xp * $x + $xa, $cy + $yp * ($y1 + 1) + $ya, $diffColor);
                     }
                 }
                 if ($start > $i * M_PI / 2 && $x <= $xStart) {
-                    $diffColor2 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], 127 - (127 - $color[3]) * $error2);
+                    $diffColor2 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], round(127 - (127 - $color[3]) * $error2));
                     $y2         = $_y2;
                     if ($aaStartX) {
                         imageSetPixel($img, $cx + $xp * $x + $xa, $cy + $yp * ($y2 - 1) + $ya, $diffColor2);
@@ -163,7 +163,7 @@ function imageSmoothArcDrawSegment(&$img, $cx, $cy, $a, $b, $aaAngleX, $aaAngleY
                     $ya = 1;
                 }
                 if ($start > $i * M_PI / 2 && $x < $xStart) {
-                    $diffColor2 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], 127 - (127 - $color[3]) * $error2);
+                    $diffColor2 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], round(127 - (127 - $color[3]) * $error2));
                     $y1         = $_y2;
                     if ($aaStartX) {
                         imageSetPixel($img, $cx + $xp * $x + $xa, $cy + $yp * ($y1 + 1) + $ya, $diffColor2);
@@ -172,14 +172,14 @@ function imageSmoothArcDrawSegment(&$img, $cx, $cy, $a, $b, $aaAngleX, $aaAngleY
                     $y         = $b * sqrt(1 - ($x * $x) / ($a * $a));
                     $error     = $y - (int) ($y);
                     $y         = (int) $y;
-                    $diffColor = imageColorExactAlpha($img, $color[0], $color[1], $color[2], 127 - (127 - $color[3]) * $error);
+                    $diffColor = imageColorExactAlpha($img, $color[0], $color[1], $color[2], round(127 - (127 - $color[3]) * $error));
                     $y1        = $y;
                     if ($x < $aaAngleX) {
                         imageSetPixel($img, $cx + $xp * $x + $xa, $cy + $yp * ($y1 + 1) + $ya, $diffColor);
                     }
                 }
                 if ($stop < ($i + 1) * M_PI / 2 && $x <= $xStop) {
-                    $diffColor1 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], 127 - (127 - $color[3]) * $error1);
+                    $diffColor1 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], round(127 - (127 - $color[3]) * $error1));
                     $y2         = $_y1;
                     if ($aaStopX) {
                         imageSetPixel($img, $cx + $xp * $x + $xa, $cy + $yp * ($y2 - 1) + $ya, $diffColor1);
@@ -239,14 +239,14 @@ function imageSmoothArcDrawSegment(&$img, $cx, $cy, $a, $b, $aaAngleX, $aaAngleY
                     $ya = 1;
                 }
                 if ($stop < ($i + 1) * (M_PI / 2) && $y <= $yStop) {
-                    $diffColor1 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], 127 - (127 - $color[3]) * $error1);
+                    $diffColor1 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], round(127 - (127 - $color[3]) * $error1));
                     $x1         = $_x1;
                     if (!$aaStopX) {
                         imageSetPixel($img, $cx + $xp * ($x1 - 1) + $xa, $cy + $yp * ($y) + $ya, $diffColor1);
                     }
                 }
                 if ($start > $i * M_PI / 2 && $y < $yStart) {
-                    $diffColor2 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], 127 - (127 - $color[3]) * $error2);
+                    $diffColor2 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], round(127 - (127 - $color[3]) * $error2));
                     $x2         = $_x2;
                     if (!$aaStartX) {
                         imageSetPixel($img, $cx + $xp * ($x2 + 1) + $xa, $cy + $yp * ($y) + $ya, $diffColor2);
@@ -255,7 +255,7 @@ function imageSmoothArcDrawSegment(&$img, $cx, $cy, $a, $b, $aaAngleX, $aaAngleY
                     $x         = $a * sqrt(1 - ($y * $y) / ($b * $b));
                     $error     = $x - (int) ($x);
                     $x         = (int) ($x);
-                    $diffColor = imageColorExactAlpha($img, $color[0], $color[1], $color[2], 127 - (127 - $color[3]) * $error);
+                    $diffColor = imageColorExactAlpha($img, $color[0], $color[1], $color[2], round(127 - (127 - $color[3]) * $error));
                     $x1        = $x;
                     if ($y < $aaAngleY && $y <= $yStop) {
                         imageSetPixel($img, $cx + $xp * ($x1 + 1) + $xa, $cy + $yp * $y + $ya, $diffColor);
@@ -279,14 +279,14 @@ function imageSmoothArcDrawSegment(&$img, $cx, $cy, $a, $b, $aaAngleX, $aaAngleY
                     $ya = 1;
                 }
                 if ($start > $i * M_PI / 2 && $y < $yStart) {
-                    $diffColor2 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], 127 - (127 - $color[3]) * $error2);
+                    $diffColor2 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], round(127 - (127 - $color[3]) * $error2));
                     $x1         = $_x2;
                     if (!$aaStartX) {
                         imageSetPixel($img, $cx + $xp * ($x1 - 1) + $xa, $cy + $yp * $y + $ya, $diffColor2);
                     }
                 }
                 if ($stop < ($i + 1) * M_PI / 2 && $y <= $yStop) {
-                    $diffColor1 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], 127 - (127 - $color[3]) * $error1);
+                    $diffColor1 = imageColorExactAlpha($img, $color[0], $color[1], $color[2], round(127 - (127 - $color[3]) * $error1));
                     $x2         = $_x1;
                     if (!$aaStopX) {
                         imageSetPixel($img, $cx + $xp * ($x2 + 1) + $xa, $cy + $yp * $y + $ya, $diffColor1);
@@ -295,7 +295,7 @@ function imageSmoothArcDrawSegment(&$img, $cx, $cy, $a, $b, $aaAngleX, $aaAngleY
                     $x         = $a * sqrt(1 - ($y * $y) / ($b * $b));
                     $error     = $x - (int) ($x);
                     $x         = (int) ($x);
-                    $diffColor = imageColorExactAlpha($img, $color[0], $color[1], $color[2], 127 - (127 - $color[3]) * $error);
+                    $diffColor = imageColorExactAlpha($img, $color[0], $color[1], $color[2], round(127 - (127 - $color[3]) * $error));
                     $x1        = $x;
                     if ($y < $aaAngleY && $y < $yStart) {
                         imageSetPixel($img, $cx + $xp * ($x1 + 1) + $xa, $cy + $yp * $y + $ya, $diffColor);


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description
- It fixes # (issue number, if applicable)
   closes #273 (most of the deprecated fields were fixed beforehand, but close_date, slaok and slako weren't).
- Here is a brief description of what this PR does
  - Fixes a few dynamic property deprecation
  - Fixes strftime deprecations
  - Fixes png related deprecations (most are float to int implicit conversion that was deprecated in php 8.1, and a removed argument in imagefilledpolygon() )