### PR TITLE
1.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [UNRELEASED] - 
+## [UNRELEASED]
 
-### Fixed
+## [1.8.9] - 2025-09-30
 
  - Fix SQL alias errors and undefined array keys
  - Fix missing `delay` to where clause

--- a/mreporting.xml
+++ b/mreporting.xml
@@ -99,6 +99,11 @@ Voir documentation : https://github.com/PluginsGLPI/mreporting/wiki
    </authors>
    <versions>
       <version>
+         <num>1.8.9</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/mreporting/releases/download/1.8.9/glpi-mreporting-1.8.9.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.9.0-beta2</num>
          <compatibility>~11.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/mreporting/releases/download/1.9.0-beta2/glpi-mreporting-1.9.0-beta2.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -28,7 +28,7 @@
  * -------------------------------------------------------------------------
  */
 
-define('PLUGIN_MREPORTING_VERSION', '1.8.8');
+define('PLUGIN_MREPORTING_VERSION', '1.8.9');
 
 // Minimal GLPI version, inclusive
 define('PLUGIN_MREPORTING_MIN_GLPI', '10.0.11');


### PR DESCRIPTION
## [1.8.9] - 2025-09-30

 - Fix SQL alias errors and undefined array keys
 - Fix missing `delay` to where clause
 - Fix weekly backlog calculation using wrong week reference point (#294)
 - Fix the SQL query for the backlog graph (#290)