### PR TITLE
1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [UNRELEASED]
+## [1.10.2] - 2026-09-01
 
 ### Fixed
 

--- a/mreporting.xml
+++ b/mreporting.xml
@@ -99,6 +99,11 @@ Voir documentation : https://github.com/PluginsGLPI/mreporting/wiki
    </authors>
    <versions>
       <version>
+         <num>1.10.2</num>
+         <compatibility>~11.0.0</compatibility>
+         <download_url>https://github.com/pluginsGLPI/mreporting/releases/download/1.10.2/glpi-mreporting-1.10.2.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.10.1</num>
          <compatibility>~11.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/mreporting/releases/download/1.10.1/glpi-mreporting-1.10.1.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -28,7 +28,7 @@
  * -------------------------------------------------------------------------
  */
 
-define('PLUGIN_MREPORTING_VERSION', '1.10.1');
+define('PLUGIN_MREPORTING_VERSION', '1.10.2');
 
 // Minimal GLPI version, inclusive
 define('PLUGIN_MREPORTING_MIN_GLPI', '11.0.0');


### PR DESCRIPTION
## [1.10.2] - 2026-09-01

### Fixed

- Escape chart labels before injecting them into report graphs
- Cast state filter values before building SQL
