### PR TITLE
1.8.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [UNRELEASED]
+
+## [1.8.12] - 2026-09-07
 
 ### Fixed
 

--- a/mreporting.xml
+++ b/mreporting.xml
@@ -2,7 +2,7 @@
    <name>More Reporting</name>
    <key>mreporting</key>
    <state>stable</state>
-   <logo>https://raw.githubusercontent.com/pluginsGLPI/mreporting/main/pics/chart-garea.png</logo>
+   <logo>https://raw.githubusercontent.com/pluginsGLPI/mreporting/main/public/pics/chart-garea.png</logo>
    <description>
       <short>
          <cs>Přidání (a vytváření) nových výkazů s grafy pro glpi</cs>

--- a/mreporting.xml
+++ b/mreporting.xml
@@ -99,6 +99,11 @@ Voir documentation : https://github.com/PluginsGLPI/mreporting/wiki
    </authors>
    <versions>
       <version>
+         <num>1.8.12</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/mreporting/releases/download/1.8.12/glpi-mreporting-1.8.12.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.8.11</num>
          <compatibility>~10.0.11</compatibility>
          <download_url>https://github.com/pluginsGLPI/mreporting/releases/download/1.8.11/glpi-mreporting-1.8.11.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -28,7 +28,7 @@
  * -------------------------------------------------------------------------
  */
 
-define('PLUGIN_MREPORTING_VERSION', '1.8.11');
+define('PLUGIN_MREPORTING_VERSION', '1.8.12');
 
 // Minimal GLPI version, inclusive
 define('PLUGIN_MREPORTING_MIN_GLPI', '10.0.11');


### PR DESCRIPTION
## [1.8.12] - 2026-09-07

### Fixed

- Fix the loss of profile rights when updating the plugin
- Fix missing categories in `reportSunburstTicketByCategories` chart.
- Escape chart labels before injecting them into report graphs
- Cast state filter values before building SQL

### Removed

- Remove the logs activity report to prevent cross-entity data display

Need https://github.com/pluginsGLPI/mreporting/pull/388